### PR TITLE
add fix to paths for sphinx documentation

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -18,9 +18,7 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
-#sys.path.insert(0,"/home/h05/gredmond/ciid_tools/lib/ciid_tools")
-sys.path.insert(0,"../lib/catnip")
+sys.path.insert(0,os.path.abspath("../lib"))
 
 # -- General configuration ------------------------------------------------
 

--- a/docsrc/tools.rst
+++ b/docsrc/tools.rst
@@ -4,7 +4,7 @@ analysis module
 .. toctree::
    :maxdepth: 2
 
-.. automodule:: analysis
+.. automodule:: catnip.analysis
     :members:
 
 preparation module
@@ -13,7 +13,7 @@ preparation module
 .. toctree::
    :maxdepth: 2
 
-.. automodule:: preparation
+.. automodule:: catnip.preparation
     :members:
 
 
@@ -23,7 +23,7 @@ visualisation module
 .. toctree::
    :maxdepth: 2
 
-.. automodule:: visualisation
+.. automodule:: catnip.visualisation
     :members:
 
 .. image:: images/regress_ci.png
@@ -38,5 +38,5 @@ utils module
 .. toctree::
    :maxdepth: 2
 
-.. automodule:: utils
+.. automodule:: catnip.utils
     :members:


### PR DESCRIPTION
when the imports were remvoed from __init__.py this broke the sphinx build. This PR has a change to the path for the library (using os.abspath per recomendatations in conf.py) and also appends catnip to the module names.