### PR TITLE
Feature test licence i128

### DIFF
--- a/bin/run_all_tests.sh
+++ b/bin/run_all_tests.sh
@@ -78,7 +78,7 @@ __TEXT__
 					if [[ -s $FILE ]]; then
 							file_contents=$(<$FILE)
 							if [[ "$file_contents" != *"$expected"* ]]; then
-
+								echo 'Licence information is not found in ' $FILE
 								count=$((count+1))
 							fi
 					fi


### PR DESCRIPTION

Running run_all_test will FAIL the licence test because of config.py file. That file doesnot contains the licence information. 
There is a separate ticket to delete config file from repo.  
But current script demonstrate that it catches the files that does not contain the licence information and reports failure. 

