### PR TITLE
add requirements directory and setup.py now use requirement.txt #174

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy==1.15.4
-matplotlib=3.3.1
-six=1.15.0
-scipy=1.5.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,0 +1,5 @@
+# file contains the list of required libraries for pip  build
+numpy
+matplotlib
+six
+scipy

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,31 @@
 import setuptools
+import os
 from distutils.core import setup
 
 
+PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+def pip_requirements(*args):
+    requirements = []
+    for name in args:
+        fname = os.path.join(
+            PACKAGE_DIR, "requirements", "{}.txt".format(name)
+        )
+        if not os.path.exists(fname):
+            emsg = (
+                f"Unable to find the {name!r} requirements file at {fname!r}."
+            )
+            raise RuntimeError(emsg)
+        with open(fname, "r") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                requirements.append(line)
+    return requirements
 
 
 setup(name='mo-catnip',
@@ -19,11 +40,7 @@ setup(name='mo-catnip',
       packages=setuptools.find_packages(where='lib'),
       package_dir={"": "lib"},
       python_requires='>=3.6',
-      install_requires=['numpy',
-                        'matplotlib',
-                        'six',
-                        'scipy'
-                        ],
+      install_requires=pip_requirements("requirements"),
       keywords = ["cmip", "climate", "analysis", "rcp"],
       classifiers=[
         "Programming Language :: Python :: 3",

--- a/test.py
+++ b/test.py
@@ -1,0 +1,32 @@
+import os
+
+
+
+PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+
+
+
+def pip_requirements(*args):
+    requirements = []
+    for name in args:
+        fname = os.path.join(
+            PACKAGE_DIR, "requirements", "{}.txt".format(name)
+        )
+        if not os.path.exists(fname):
+            emsg = (
+                f"Unable to find the {name!r} requirements file at {fname!r}."
+            )
+            raise RuntimeError(emsg)
+        with open(fname, "r") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                requirements.append(line)
+    return requirements
+
+
+req = pip_requirements("requirements")
+print(req)


### PR DESCRIPTION

Updates: 
Create requirements directory. 
setup.py uses requirement.txt 

How to test? use the following command to build the distribution:
python setup.py sdist

it will create the directory "dist" which will contain .tar of CATNIP.



