### PR TITLE
Update default-next.yml

### DIFF
--- a/envs/default-next.yml
+++ b/envs/default-next.yml
@@ -14,4 +14,4 @@ dependencies:
   - imagehash
   - pytest
   - flake8
-  - sphinx=3.4.3
+  - sphinx>5,<6


### PR DESCRIPTION
try using more up to date version of sphinx to avoid issues with Jinja. Without this change, the deafault-next sphinx build fails due to incompatible versions of sphinx and jinja